### PR TITLE
Fix: Correct SyntaxError in addon decoding logic

### DIFF
--- a/proxyapp.py
+++ b/proxyapp.py
@@ -670,14 +670,6 @@ class AuditorAddon:
             "req_host": flow.request.host, # Added req_host
             "req_headers": dict(flow.request.headers),
             "req_body_bytes": flow.request.content or b'',
-    req_decoded_text, req_encoding_name, req_editable_flag = Codec.auto_decode(
-        flow_data["req_body_bytes"],
-        flow_data["req_headers"],
-        flow
-    )
-    flow_data["req_decoded_text"] = req_decoded_text
-    flow_data["req_encoding_name"] = req_encoding_name
-    flow_data["req_editable_flag"] = req_editable_flag
             "req_http_version": flow.request.http_version,
             "req_is_http10": flow.request.is_http10,
             "req_is_http11": flow.request.is_http11,
@@ -694,14 +686,6 @@ class AuditorAddon:
                 "resp_reason": flow.response.reason,
                 "resp_headers": dict(flow.response.headers),
                 "resp_body_bytes": flow.response.content or b'',
-    resp_decoded_text, resp_encoding_name, resp_editable_flag = Codec.auto_decode(
-        flow_data["resp_body_bytes"],
-        flow_data["resp_headers"],
-        flow
-    )
-    flow_data["resp_decoded_text"] = resp_decoded_text
-    flow_data["resp_encoding_name"] = resp_encoding_name
-    flow_data["resp_editable_flag"] = resp_editable_flag
                 "resp_http_version": flow.response.http_version,
                 "resp_is_http10": flow.response.is_http10,
                 "resp_is_http11": flow.response.is_http11,
@@ -720,9 +704,6 @@ class AuditorAddon:
                 "resp_reason": "N/A",
                 "resp_headers": {},
                 "resp_body_bytes": b'',
-    flow_data["resp_decoded_text"] = ""
-    flow_data["resp_encoding_name"] = "TEXT (Empty)"
-    flow_data["resp_editable_flag"] = True
                 "resp_http_version": "N/A",
                 "resp_is_http10": False,
                 "resp_is_http11": False,
@@ -734,6 +715,32 @@ class AuditorAddon:
                 "timestamp_end": "N/A",
                 "timestamp_end_raw": 0,
             })
+
+    # Request decoding (occurs *after* flow_data is initialized)
+    req_decoded_text, req_encoding_name, req_editable_flag = Codec.auto_decode(
+        flow_data["req_body_bytes"], # Use raw bytes from flow_data
+        flow_data["req_headers"],    # Use headers from flow_data
+        flow                       # Pass the live flow object
+    )
+    flow_data["req_decoded_text"] = req_decoded_text
+    flow_data["req_encoding_name"] = req_encoding_name
+    flow_data["req_editable_flag"] = req_editable_flag
+
+    # Response decoding (occurs *after* flow_data is initialized)
+    if flow.response:
+        resp_decoded_text, resp_encoding_name, resp_editable_flag = Codec.auto_decode(
+            flow_data["resp_body_bytes"], # Use raw bytes from flow_data
+            flow_data["resp_headers"],    # Use headers from flow_data
+            flow                          # Pass the live flow object
+        )
+        flow_data["resp_decoded_text"] = resp_decoded_text
+        flow_data["resp_encoding_name"] = resp_encoding_name
+        flow_data["resp_editable_flag"] = resp_editable_flag
+    else:
+        # Ensure these keys are present even if there's no response
+        flow_data["resp_decoded_text"] = ""
+        flow_data["resp_encoding_name"] = "TEXT (Empty)"
+        flow_data["resp_editable_flag"] = True
         
         if flow.error:
             flow_data["error_msg"] = str(flow.error.msg)


### PR DESCRIPTION
Resolved a SyntaxError in the AuditorAddon._extract_flow_data method that occurred during the previous refactoring attempt. The error was caused by incorrectly placing decoding logic and variable assignments within the initial flow_data dictionary definition.

This commit corrects the structure by:
1. Initializing the flow_data dictionary with all raw flow information first.
2. Performing content decoding (Codec.auto_decode for request and response) in a separate step *after* the dictionary is created, using the live flow object.
3. Adding the decoded text, encoding name, and editable flag as new keys to the flow_data dictionary.

This finalizes the architectural shift of moving content decoding from the GUI layer to the proxy addon, ensuring that decoders like ContextualDecoder operate on the live mitmproxy.http.HTTPFlow object and that the application runs without syntax errors. The GUI methods remain simplified, consuming pre-decoded data from the flow_data dictionary.